### PR TITLE
fixes websocket wss connection problems once deployed

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -17,7 +17,7 @@ import { io } from "socket.io-client";
 import Layout from './components/Wallet/components/Layout';
 import Welcome from './components/Wallet/components/Welcome';
 import Builder from './components/Builder';
-import TransactionMain  from './components/Bagpipes/CustomNodes/transactionReview/TransactionMain';
+import TransactionMain  from './components/Bagpipes/CustomNodes/TransactionReview/TransactionMain';
 import ReactTestFlow from './ReactTestFlow';
 import WalletInfo from './components/Wallet/pages/WalletInfo';
 import initializeKeyring from './services/initializeKeyring';

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,7 +2,6 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import topLevelAwait from "vite-plugin-top-level-await";
 
-
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [
@@ -12,6 +11,14 @@ export default defineConfig({
       promiseImportName: i => `__tla_${i}`
     })  
   ],
+  server: {
+       host: true,
+	      port: 5173,
+	      strictPort: true,
+	  hmr: {
+      overlay: false, // Disable HMR overlay
+    },
+  },
   allowImportingTsExtensions: true,
   define: {
     // By default, Vite doesn't include shims for NodeJS/


### PR DESCRIPTION
Fixes websocket failing when deploying with tls(https)

Error:
```js
Uncaught (in promise) DOMException: Failed to construct 'WebSocket': The URL 'wss://localhost:undefined/' is invalid.
```

Enable vite's  strictPort and disables hmr overlay
